### PR TITLE
Add PumpkinPi GPIO Zero class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Programmable Pumpkin - Sample Code
+# PumpkinPi - Sample Code
 
-Here you will find three different code examples to get you started with the Pumpkin Pi from ModMyPi.
+Here you will find three different code examples to get you started with the PumpkinPi from ModMyPi.
 
 There is either a [kit you can build](https://www.modmypi.com/raspberry-pi/led-displays-and-drivers-1034/led-boards-1040/halloween-pumpkin-solder-kit) or a [pre-assembled Pumpkin](https://www.modmypi.com/raspberry-pi/led-displays-and-drivers-1034/led-boards-1040/halloween-pumpkin-programmable-kit) for you to get your Halloween spook on with.
 

--- a/pumpkinpi.py
+++ b/pumpkinpi.py
@@ -1,0 +1,35 @@
+from gpiozero import LEDBoard
+
+class PumpkinPi(LEDBoard):
+    # Set up a PumpkinPi using GPIO Zero to build a class.
+    # To use:
+    # pumpkin = PumpkinPi() for a simple instance using LED class.
+    # pumpkin = PumpkinPi(pwm=True) for a version which can use PWM.
+    # See example files in this repo for more examples of use...
+    def __init__(self, pwm=False, initial_value=False, pin_factory=None):
+        super(PumpkinPi,self).__init__(
+            sides=LEDBoard(
+                left=LEDBoard(
+                    bottom=18, midbottom=17, middle=16, midtop=13, top=24,
+                    pwm=pwm, initial_value=initial_value,
+                    _order=('bottom','midbottom','middle','midtop','top'),
+                    pin_factory=pin_factory),
+                right=LEDBoard(
+                    bottom=19, midbottom=20, middle=21, midtop=22, top=23,
+                    pwm=pwm, initial_value=initial_value,
+                    _order=('bottom','midbottom','middle','midtop','top'),
+                    pin_factory=pin_factory),
+                pwm=pwm, initial_value=initial_value,
+                _order=('left','right'),
+                pin_factory=pin_factory
+                ),
+            eyes=LEDBoard(
+                left=12, right=6,
+                pwm=pwm, initial_value=initial_value,
+                _order=('left','right'),
+                pin_factory=pin_factory
+                ),
+            pwm=pwm, initial_value=initial_value,
+            _order=('eyes','sides'),
+            pin_factory=pin_factory
+        )


### PR DESCRIPTION
Add new PumpkinPi class to allow users to use [GPIO Zero](https://gpiozero.readthedocs.io) to control the LEDs on the PumpkinPi board.